### PR TITLE
fix: let OS assign TUN interface name dynamically to avoid EBUSY on r…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -180,7 +180,7 @@ pub async fn spawn_server(&self, region: &str) -> Result<ServerInfo> {
 2. Mark with `#[tauri::command]`
 3. Return `Result<T, String>` for errors
 4. Register in `main.rs`
-5. Call from React with `invoke('command_name', { args })`
+5. Call from React with `invokeCommand('command_name', { args })`
 
 ### Adding a New Hook
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byocvpn_aws"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "byocvpn_azure"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "byocvpn_cli"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "byocvpn_aws",
  "byocvpn_core",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "byocvpn_core"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "byocvpn_daemon"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "byocvpn_gcp"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "byocvpn_core",
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "byocvpn_oracle"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "ui"
-version = "0.1.0"
+version = "0.1.11"
 dependencies = [
  "byocvpn_aws",
  "byocvpn_azure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
     "crates/infra/azure",
 ]
 
+[workspace.package]
+version = "0.1.11"
+
 [workspace.dependencies]
 tokio = { version = "1.48.0", features = ["full"] }
 async-trait = "0.1.89"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byocvpn_cli"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byocvpn_core"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byocvpn_daemon"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/crates/daemon/src/constants.rs
+++ b/crates/daemon/src/constants.rs
@@ -2,15 +2,6 @@ use std::path::PathBuf;
 
 pub const TUNNEL_MTU: u16 = 1280;
 
-pub fn get_interface_name() -> &'static str {
-    #[cfg(target_os = "macos")]
-    return "utun4";
-    #[cfg(windows)]
-    return "byocvpn";
-    #[cfg(not(any(target_os = "macos", windows)))]
-    return "tun0";
-}
-
 #[cfg(unix)]
 fn socket_dir() -> PathBuf {
     if cfg!(debug_assertions) {

--- a/crates/daemon/src/vpn/connect.rs
+++ b/crates/daemon/src/vpn/connect.rs
@@ -121,7 +121,6 @@ pub async fn connect_vpn(params: VpnConnectParams) -> Result<()> {
 
 fn setup_tun_device(private_ipv4: IpNet, private_ipv6: IpNet) -> Result<(AsyncDevice, u32)> {
     let tun = DeviceBuilder::new()
-        .name(constants::get_interface_name())
         .ipv4(private_ipv4.addr(), private_ipv4.prefix_len(), None)
         .ipv6(private_ipv6.addr(), private_ipv6.prefix_len())
         .mtu(constants::TUNNEL_MTU)
@@ -136,7 +135,8 @@ fn setup_tun_device(private_ipv4: IpNet, private_ipv6: IpNet) -> Result<(AsyncDe
                 reason: format!("Failed to get TUN interface index: {}", error),
             })?;
 
-    info!("Created TUN device: {} (index: {})", constants::get_interface_name(), interface_index);
+    let interface_name = tun.name().unwrap_or_else(|_| "unknown".to_string());
+    info!("Created TUN device: {} (index: {})", interface_name, interface_index);
     Ok((tun, interface_index))
 }
 

--- a/crates/infra/aws/Cargo.toml
+++ b/crates/infra/aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byocvpn_aws"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/crates/infra/azure/Cargo.toml
+++ b/crates/infra/azure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byocvpn_azure"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/crates/infra/gcp/Cargo.toml
+++ b/crates/infra/gcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byocvpn_gcp"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/crates/infra/oracle/Cargo.toml
+++ b/crates/infra/oracle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "byocvpn_oracle"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/crates/ui/package.json
+++ b/crates/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "private": true,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/crates/ui/src-tauri/Cargo.toml
+++ b/crates/ui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.1.0"
+version = "0.1.11"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2024"

--- a/crates/ui/src-tauri/Cargo.toml
+++ b/crates/ui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ui"
-version = "0.1.11"
+version.workspace = true
 description = "A Tauri App"
 authors = ["you"]
 edition = "2024"

--- a/crates/ui/src-tauri/tauri.conf.json
+++ b/crates/ui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ByocVPN",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "com.byocvpn.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/ui/src/components/regions/RegionSelector.tsx
+++ b/crates/ui/src/components/regions/RegionSelector.tsx
@@ -2,7 +2,7 @@ import { useInstancesContext } from "../../contexts";
 import { getRegionInfo } from "../../types/regionInfo";
 import { FlagIcon } from "../FlagIcon";
 import { useEffect, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../../lib/invokeCommand";
 import { listen } from "@tauri-apps/api/event";
 import { load as loadStore } from "@tauri-apps/plugin-store";
 import toast from "react-hot-toast";
@@ -58,7 +58,7 @@ export function RegionSelector({
   useEffect(() => {
     setIsLoadingRegions(true);
     setSelectedRegion(null);
-    invoke<SimpleRegion[]>("get_regions", { provider })
+    invokeCommand<SimpleRegion[]>("get_regions", { provider })
       .then(async (regions) => {
         const groups: Record<string, SimpleRegion[]> = {};
         regions.forEach((region) => {
@@ -142,7 +142,7 @@ export function RegionSelector({
   ) => {
     event.stopPropagation();
     try {
-      const job = await invoke<EnableRegionJob>("enable_region", {
+      const job = await invokeCommand<EnableRegionJob>("enable_region", {
         region: region.name,
         provider,
       });

--- a/crates/ui/src/components/settings/NotificationSettingsCard.tsx
+++ b/crates/ui/src/components/settings/NotificationSettingsCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../../lib/invokeCommand";
 import { isPermissionGranted, requestPermission } from "@tauri-apps/plugin-notification";
 
 interface NotificationSettings {
@@ -17,14 +17,14 @@ export function NotificationSettingsCard() {
   const [permissionError, setPermissionError] = useState<string | null>(null);
 
   useEffect(() => {
-    invoke<NotificationSettings>("get_notification_settings")
+    invokeCommand<NotificationSettings>("get_notification_settings")
       .then(setSettings)
       .catch((error) => console.error("Failed to load notification settings:", error));
   }, []);
 
   const updateSettings = (updated: NotificationSettings) => {
     setSettings(updated);
-    invoke("save_notification_settings", { settings: updated }).catch((error) =>
+    invokeCommand("save_notification_settings", { settings: updated }).catch((error) =>
       console.error("Failed to save notification settings:", error),
     );
   };

--- a/crates/ui/src/hooks/useCredentials.ts
+++ b/crates/ui/src/hooks/useCredentials.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import toast from "react-hot-toast";
 
 export interface AwsCredentials {
@@ -42,7 +42,7 @@ export const useCredentials = () => {
     | null
   > => {
     try {
-      return await invoke("get_credentials", { provider });
+      return await invokeCommand("get_credentials", { provider });
     } catch {
       return null;
     }
@@ -61,7 +61,7 @@ export const useCredentials = () => {
     setSuccessMessage(null);
 
     try {
-      await invoke("save_credentials", { provider, creds });
+      await invokeCommand("save_credentials", { provider, creds });
       const message = "Credentials saved successfully!";
       setSuccessMessage(message);
       toast.success(message);
@@ -82,7 +82,7 @@ export const useCredentials = () => {
     provider: "aws" | "oracle" | "gcp" | "azure",
   ): Promise<boolean> => {
     try {
-      await invoke("delete_credentials", { provider });
+      await invokeCommand("delete_credentials", { provider });
       toast.success("Credentials deleted successfully!");
       return true;
     } catch (err) {

--- a/crates/ui/src/hooks/useInstances.ts
+++ b/crates/ui/src/hooks/useInstances.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import { listen } from "@tauri-apps/api/event";
 import toast from "react-hot-toast";
 import {
@@ -99,7 +99,7 @@ export const useInstances = (regions: AwsRegion[]) => {
     setIsLoading(true);
     setError(null);
     try {
-      const fetched = await invoke<Instance[]>("list_instances");
+      const fetched = await invokeCommand<Instance[]>("list_instances");
       setInstances(fetched);
     } catch (err) {
       const message =
@@ -130,7 +130,7 @@ export const useInstances = (regions: AwsRegion[]) => {
     setInstances((prev) => [...prev, placeholder]);
 
     try {
-      const job = await invoke<SpawnJob>("spawn_instance", {
+      const job = await invokeCommand<SpawnJob>("spawn_instance", {
         region: regionName,
         provider,
       });
@@ -167,7 +167,7 @@ export const useInstances = (regions: AwsRegion[]) => {
     setTerminatingInstanceId(instanceId);
     setError(null);
     try {
-      await invoke("terminate_instance", { instanceId, region, provider });
+      await invokeCommand("terminate_instance", { instanceId, region, provider });
       setInstances((prev) => prev.filter((i) => i.id !== instanceId));
       toast.success("Server terminated successfully!");
     } catch (err) {

--- a/crates/ui/src/hooks/useLedger.ts
+++ b/crates/ui/src/hooks/useLedger.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import { LedgerEntry, LedgerEntryWithCost, PricingInfo } from "../types/ledger";
 
 
@@ -22,14 +22,14 @@ export const useLedger = () => {
     setIsLoading(true);
     setError(null);
     try {
-      const rawEntries = await invoke<LedgerEntry[]>("get_ledger");
+      const rawEntries = await invokeCommand<LedgerEntry[]>("get_ledger");
 
       const pricingCache = new Map<string, PricingInfo>();
       for (const entry of rawEntries) {
         const key = `${entry.provider}::${entry.instanceType}`;
         if (!pricingCache.has(key)) {
           try {
-            const pricing = await invoke<PricingInfo>("get_instance_pricing", {
+            const pricing = await invokeCommand<PricingInfo>("get_instance_pricing", {
               provider: entry.provider,
               instanceType: entry.instanceType,
             });

--- a/crates/ui/src/hooks/useProfile.ts
+++ b/crates/ui/src/hooks/useProfile.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import toast from "react-hot-toast";
 
 export const useProfile = () => {
@@ -11,7 +11,7 @@ export const useProfile = () => {
     setError(null);
 
     try {
-      const hasProfile = (await invoke("has_profile")) as boolean;
+      const hasProfile = (await invokeCommand("has_profile")) as boolean;
       return hasProfile;
     } catch (error) {
       const errorMessage =

--- a/crates/ui/src/hooks/useRegions.ts
+++ b/crates/ui/src/hooks/useRegions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import toast from "react-hot-toast";
 import { AwsRegion, RegionGroup } from "../types";
 
@@ -41,7 +41,7 @@ const fetchConfiguredProviders = async (): Promise<Provider[]> => {
   const checks = await Promise.all(
     PROVIDERS.map(async (provider) => {
       try {
-        const credentials = await invoke("get_credentials", { provider });
+        const credentials = await invokeCommand("get_credentials", { provider });
         return credentials !== null ? provider : null;
       } catch {
         return null;
@@ -67,7 +67,7 @@ export const useRegions = () => {
       }
 
       const primaryProvider = configuredProviders[0];
-      const fetchedRegions = (await invoke("get_regions", {
+      const fetchedRegions = (await invokeCommand("get_regions", {
         provider: primaryProvider,
       })) as AwsRegion[];
       setRegions(fetchedRegions);

--- a/crates/ui/src/hooks/useVpnConnection.ts
+++ b/crates/ui/src/hooks/useVpnConnection.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import toast from "react-hot-toast";
@@ -56,10 +56,10 @@ export const useVpnConnection = () => {
 
   const checkVpnStatus = async () => {
     try {
-      const status = await invoke<VpnStatus>("get_vpn_status");
+      const status = await invokeCommand<VpnStatus>("get_vpn_status");
       setVpnStatus(status);
       if (status.connected) {
-        invoke("subscribe_to_vpn_status").catch((error) =>
+        invokeCommand("subscribe_to_vpn_status").catch((error) =>
           console.error("Failed to resume metrics stream:", error),
         );
       }
@@ -75,7 +75,7 @@ export const useVpnConnection = () => {
     setError(null);
 
     try {
-      const response = await invoke("connect", {
+      const response = await invokeCommand("connect", {
         instanceId: selectedInstance.id,
         region: selectedInstance.region,
         provider: selectedInstance.provider,
@@ -100,7 +100,7 @@ export const useVpnConnection = () => {
     setError(null);
 
     try {
-      const response = await invoke("disconnect");
+      const response = await invokeCommand("disconnect");
       console.log("VPN disconnected:", response);
       toast.success("Disconnected from VPN");
     } catch (error) {

--- a/crates/ui/src/lib/invokeCommand.ts
+++ b/crates/ui/src/lib/invokeCommand.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 
 export async function invokeCommand<T>(
   command: string,
-  args?: Record<string, unknown>
+  args?: Record<string, unknown>,
 ): Promise<T> {
   try {
     return await invoke<T>(command, args);

--- a/crates/ui/src/lib/invokeCommand.ts
+++ b/crates/ui/src/lib/invokeCommand.ts
@@ -1,0 +1,12 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export async function invokeCommand<T>(
+  command: string,
+  args?: Record<string, unknown>
+): Promise<T> {
+  try {
+    return await invoke<T>(command, args);
+  } catch (error) {
+    throw new Error(error as string);
+  }
+}

--- a/crates/ui/src/pages/AddAccountPage.tsx
+++ b/crates/ui/src/pages/AddAccountPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import { listen } from "@tauri-apps/api/event";
 import { save } from "@tauri-apps/plugin-dialog";
 import toast from "react-hot-toast";
@@ -369,7 +369,7 @@ export function AddAccountPage({ onNavigateBack, onAccountAdded }: AddAccountPag
   const startProvisioning = async (provider: string) => {
     try {
       earlyProgressEventsRef.current = [];
-      const job = await invoke<ProvisionAccountJob>("provision_account", { provider });
+      const job = await invokeCommand<ProvisionAccountJob>("provision_account", { provider });
       const bufferedEvents = earlyProgressEventsRef.current.filter((event) => event.jobId === job.jobId);
       earlyProgressEventsRef.current = [];
       const initialSteps: SpawnStepState[] = job.steps.map((provisionStep) => {
@@ -914,7 +914,7 @@ function PolicyBox({ policy }: PolicyBoxProps) {
   const handleDownload = async () => {
     const savePath = await save({ defaultPath: policy.filename });
     if (savePath) {
-      await invoke("save_file", { path: savePath, content: policy.content });
+      await invokeCommand("save_file", { path: savePath, content: policy.content });
     }
   };
 

--- a/crates/ui/src/pages/SettingsPage.tsx
+++ b/crates/ui/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invokeCommand } from "../lib/invokeCommand";
 import { listen } from "@tauri-apps/api/event";
 import { load as loadStore } from "@tauri-apps/plugin-store";
 import toast from "react-hot-toast";
@@ -116,7 +116,7 @@ export function SettingsPage({ onNavigateToAddAccount }: SettingsPageProps) {
 
   const startProvisionAccount = async (provider: string) => {
     try {
-      const job = await invoke<ProvisionAccountJob>("provision_account", {
+      const job = await invokeCommand<ProvisionAccountJob>("provision_account", {
         provider,
       });
 


### PR DESCRIPTION
…econnect

Hardcoding the interface name (utun4/tun0) caused "resource busy" errors when reconnecting after a daemon crash, or when another VPN already held that name. Dropping .name() from DeviceBuilder lets tun-rs pass an empty ifr_name/unit=0, so the kernel assigns the next free interface — the same approach used by WireGuard-go and OpenVPN's default --dev tun mode.

Bump version to 0.1.11